### PR TITLE
[Design] 탭바 부분 수정

### DIFF
--- a/StudyGaemi/Controllers/SettingViewController.swift
+++ b/StudyGaemi/Controllers/SettingViewController.swift
@@ -272,6 +272,7 @@ class SettingViewController: BaseViewController, UITableViewDelegate, UITableVie
             self.imagePicker.sourceType = .photoLibrary
             self.imagePicker.modalPresentationStyle = .currentContext
             self.present(self.imagePicker, animated: true, completion: nil)
+            self.tabBarController?.tabBar.isHidden = true
         } else {
             print("앨범에 접근할 수 없습니다.")
         }
@@ -282,6 +283,7 @@ class SettingViewController: BaseViewController, UITableViewDelegate, UITableVie
             self.imagePicker.sourceType = .camera
             self.imagePicker.modalPresentationStyle = .currentContext
             self.present(self.imagePicker, animated: true, completion: nil)
+            self.tabBarController?.tabBar.isHidden = true
         } else {
             print("카메라에 접근할 수 없습니다.")
         }
@@ -295,7 +297,14 @@ class SettingViewController: BaseViewController, UITableViewDelegate, UITableVie
         settingView.userImageView.image = selectedImage
         saveProfileImage(image: selectedImage)
         picker.dismiss(animated: true, completion: nil)
+        self.tabBarController?.tabBar.isHidden = false
     }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            picker.dismiss(animated: true) {
+                self.tabBarController?.tabBar.isHidden = false
+            }
+        }
 
     private func saveProfileImage(image: UIImage) {
         let fileName = UUID().uuidString

--- a/StudyGaemi/Views/Setting/SettingView.swift
+++ b/StudyGaemi/Views/Setting/SettingView.swift
@@ -151,7 +151,8 @@ class SettingView: UIView {
         
         scrollView.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide)
-            make.leading.trailing.bottom.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalToSuperview().inset(30)
         }
         
         scrollContentView.snp.makeConstraints { make in


### PR DESCRIPTION
탭바 수정, 스크롤 시 탭바 밑 공간으로 로그아웃 버튼 보이는 부분 수정

# 스크린 샷 추가 📸

|기능  |스크린 샷
|:-:  |:-:
|이미지  |![image](https://github.com/8tTruck/StudyGaemi/assets/133753824/24852d8e-aff7-435c-971a-174471ddba8a)


# 어떤 변경 사항이 있나요?？

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

# PR이 다음 요구 사항을 충족하는지 확인하세요‼️

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
